### PR TITLE
Silicon Door Opening

### DIFF
--- a/code/_onclick/ai_onclick.dm
+++ b/code/_onclick/ai_onclick.dm
@@ -69,6 +69,11 @@
 	if(world.time <= next_move)
 		return
 
+	if(isturf(A))
+		var/turf/clicked_turf = A
+		for(var/obj/machinery/door/AL in clicked_turf.contents)
+			AL.try_to_activate_door(src)
+
 	if(aiCamera.in_camera_mode)
 		aiCamera.camera_mode_off()
 		aiCamera.captureimage(A, usr)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -57,6 +57,11 @@
 
 	face_atom(A) // change direction to face what you clicked on
 
+	if(isturf(A))
+		var/turf/clicked_turf = A
+		for(var/obj/machinery/door/AL in clicked_turf.contents)
+			AL.try_to_activate_door(src)
+
 	if(aiCamera)
 		if(aiCamera.in_camera_mode)
 			aiCamera.camera_mode_off()


### PR DESCRIPTION
## What Does This PR Do
Extends the basic functionality of door operation to silicons.
## Why It's Good For The Game
Less pixel hunting for silicons.
## Testing
Closed open doors by clicking on tiles as both borg and AI.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
add: Extends the basic functionality of door operation to silicons.
/:cl: